### PR TITLE
Remove dot notation for attribute references

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,7 @@ Cfoo Shortcut: `$(SubnetConfig[VPC][CIDR])`
 
 CloudFormation: `{ "Fn::GetAtt" : [ "Ec2Instance", "PublicIp" ] }`
 
-Cfoo Shortcut: `$(Ec2Instance.PublicIp)`
-
-Other Shortcut: `$(Ec2Instance[PublicIp])`
+Cfoo Shortcut: `$(Ec2Instance[PublicIp])`
 
 ##### Embedded Reference
 

--- a/features/attribute_expansion.feature
+++ b/features/attribute_expansion.feature
@@ -8,7 +8,7 @@ Feature: Expand EL Attribute References
         """
         EntryPoint:
             Description: IP address of the Bastion Host
-            Value: $(BastionHost.PublicIp)
+            Value: $(BastionHost[PublicIp])
         """
         When I process "outputs.yml"
         Then the output should match JSON
@@ -27,7 +27,7 @@ Feature: Expand EL Attribute References
         """
         WebSite:
             Description: URL of the website
-            Value: http://$(PublicElasticLoadBalancer.DNSName)/index.html
+            Value: http://$(PublicElasticLoadBalancer[DNSName])/index.html
         """
         When I process "outputs.yml"
         Then the output should match JSON

--- a/lib/cfoo/el_parser.rb
+++ b/lib/cfoo/el_parser.rb
@@ -28,13 +28,12 @@ module Cfoo
         rule(:dot) { str('.') }
         rule(:comma) { str(",") >> space? }
         rule(:text_character) { match['^\\\\$'] }
-        rule(:identifier) { match['a-zA-Z0-9_\-:'].repeat(1).as(:identifier) >> space? }
+        rule(:identifier) { match['a-zA-Z0-9._\-:'].repeat(1).as(:identifier) >> space? }
         rule(:text) { text_character.repeat(1).as(:text) }
 
         rule(:attribute_reference) do
             (
                 expression.as(:reference) >> (
-                    str(".") >> identifier.as(:attribute) |
                     str("[") >> expression.as(:attribute) >> str("]")
                 )
             ).as(:attribute_reference)

--- a/spec/cfoo/el_parser_spec.rb
+++ b/spec/cfoo/el_parser_spec.rb
@@ -7,6 +7,10 @@ module Cfoo
             parser.parse("$(orange)").should == {"Ref" => "orange"}
         end
 
+        it 'turns simple EL references with dots into CloudFormation "Ref" maps' do
+            parser.parse("$(orange.color)").should == {"Ref" => "orange.color"}
+        end
+
         it 'turns EL references embedded in strings into appended arrays' do
             parser.parse("large $(MelonType) melon").should == {"Fn::Join" => [ "" , [ "large ", { "Ref" => "MelonType" }, " melon" ]]}
         end
@@ -15,12 +19,12 @@ module Cfoo
             parser.parse("I have $(number) apples and $(otherNumber) oranges").should == {"Fn::Join" => [ "" , ["I have ", { "Ref" => "number" }, " apples and ", { "Ref" => "otherNumber" }, " oranges" ]]}
         end
 
-        it 'turns EL attribute references into CloudFormation "GetAtt" maps' do
-            parser.parse("$(apple.color)").should == {"Fn::GetAtt" => ["apple", "color"]}
-        end
-
         it 'turns EL attribute map references into CloudFormation "GetAtt" maps' do
             parser.parse("$(apple[color])").should == {"Fn::GetAtt" => ["apple", "color"]}
+        end
+
+        it 'turns EL attribute map references with dots into CloudFormation "GetAtt" maps' do
+            parser.parse("$(apple[color.primary])").should == {"Fn::GetAtt" => ["apple", "color.primary"]}
         end
 
         it 'turns EL map references into CloudFormation "FindInMap" maps' do

--- a/spec/cfoo/parser_spec.rb
+++ b/spec/cfoo/parser_spec.rb
@@ -51,6 +51,11 @@ module Cfoo
                     parser.parse_file("myfile.yml").should == {"Ref" => "orange"}
                 end
 
+                it 'turns simple EL references with dots into CloudFormation "Ref" maps' do
+                    file_system.should_receive(:parse_file).with("myfile.yml").and_return("$(orange.color)")
+                    parser.parse_file("myfile.yml").should == {"Ref" => "orange.color"}
+                end
+
                 it 'turns EL references embedded in strings into appended arrays' do
                     file_system.should_receive(:parse_file).with("myfile.yml").and_return("large $(MelonType) melon")
                     parser.parse_file("myfile.yml").should == {"Fn::Join" => [ "", [ "large ", { "Ref" => "MelonType" }, " melon" ] ] }
@@ -63,8 +68,13 @@ module Cfoo
                 end
 
                 it 'turns EL attribute references into CloudFormation "GetAtt" maps' do
-                    file_system.should_receive(:parse_file).with("myfile.yml").and_return("$(apple.color)")
+                    file_system.should_receive(:parse_file).with("myfile.yml").and_return("$(apple[color])")
                     parser.parse_file("myfile.yml").should == {"Fn::GetAtt" => ["apple", "color"]}
+                end
+
+                it 'turns EL attribute references with dots into CloudFormation "GetAtt" maps' do
+                    file_system.should_receive(:parse_file).with("myfile.yml").and_return("$(apple[color.primary])")
+                    parser.parse_file("myfile.yml").should == {"Fn::GetAtt" => ["apple", "color.primary"]}
                 end
 
                 it 'turns EL map references into CloudFormation "FindInMap" maps' do


### PR DESCRIPTION
Dots are valid characters in attribute names and are used specifically
by Redshift and RDS. Possible fix for drrb/cfoo#1
