### PR TITLE
Allow empty string to intrinsic function !GetAZs

### DIFF
--- a/features/yamly_shortcuts.feature
+++ b/features/yamly_shortcuts.feature
@@ -88,6 +88,20 @@ Feature: YAMLy shortcuts
         }
         """
 
+    Scenario: AZ listing with empty string
+        Given I have a file "map.yml" containing
+        """
+        AvailabilityZones: !GetAZs
+        """
+        When I process "map.yml"
+        Then the output should match JSON
+        """
+        {
+            "AWSTemplateFormatVersion" : "2010-09-09",
+            "AvailabilityZones" : { "Fn::GetAZs" : "" }
+        }
+        """
+
     Scenario: Base64 string
         Given I have a file "multistring.yml" containing
         """

--- a/lib/cfoo/parser.rb
+++ b/lib/cfoo/parser.rb
@@ -65,6 +65,12 @@ module YAML
             case type_id
             when "Ref"
                 { "Ref" => value.expand_el }
+            when "GetAZs"
+                if value.nil?
+                    { "Fn::GetAZs" => "" }
+                else
+                    { "Fn::GetAZs" => value.expand_el }
+                end
             when CLOUDFORMATION_FUNCTION_REGEX
                 { "Fn::#{type_id}" => value.expand_el }
             when "Concat"

--- a/spec/cfoo/yaml_parser_spec.rb
+++ b/spec/cfoo/yaml_parser_spec.rb
@@ -71,6 +71,11 @@ module Cfoo
 
                     parser.load_file("#{working_dir}/get_azs.yml").should == YAML::DomainType.create("GetAZs", "myregion")
                 end
+                it "converts empty AZ lookups to GetAZs function-calls" do
+                    write "#{working_dir}/get_azs_empty.yml", "!GetAZs"
+
+                    parser.load_file("#{working_dir}/get_azs_empty.yml").should == YAML::DomainType.create("GetAZs", nil)
+                end
             end
         end
 


### PR DESCRIPTION
As per spec !GetAZs "" is allowed and equivalent to !GetAZs $(AWS::Region)

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html
